### PR TITLE
fix loading of events on initial start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Version 1.0.2  - (in development)
+- stay tuned
+
+## Version 1.0.1
+- fix: load items on first start
+
+## Version 1.0.0
+- initial code drop

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.gdg.berlin.android.events"
         minSdkVersion 19
         targetSdkVersion 24
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
     }
 
     buildTypes {

--- a/app/src/main/java/org/gdg/berlin/android/events/ui/interactor/EventListInteractor.java
+++ b/app/src/main/java/org/gdg/berlin/android/events/ui/interactor/EventListInteractor.java
@@ -1,5 +1,6 @@
 package org.gdg.berlin.android.events.ui.interactor;
 
+import com.contentful.vault.SyncResult;
 import com.contentful.vault.Vault;
 
 import java.util.ArrayList;
@@ -9,6 +10,8 @@ import org.gdg.berlin.android.events.cms.Event;
 import rx.Subscriber;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
 
 public class EventListInteractor {
 
@@ -20,7 +23,8 @@ public class EventListInteractor {
 
   private final Vault vault;
 
-  private Subscription subscription;
+  private Subscription vaultSyncSubscription;
+  private Subscription eventListSubscription;
 
   public EventListInteractor(Vault vault) {
     this.vault = vault;
@@ -31,15 +35,28 @@ public class EventListInteractor {
       throw new IllegalArgumentException("Listener cannot be null!");
     }
 
-    subscription = vault.observe(Event.class)
+    vaultSyncSubscription = Vault.observeSyncResults()
+        .subscribeOn(Schedulers.io())
+        .subscribe(new Action1<SyncResult>() {
+          @Override public void call(SyncResult syncResult) {
+            if (syncResult.isSuccessful()) {
+              requestEvents(listener);
+            } else {
+              listener.onError(syncResult.error());
+            }
+          }
+        });
+  }
+
+  private void requestEvents(final Listener listener) {
+    eventListSubscription = vault.observe(Event.class)
         .all()
-        .subscribeOn(AndroidSchedulers.mainThread())
+        .observeOn(AndroidSchedulers.mainThread())
         .subscribe(new Subscriber<Event>() {
           final List<Event> eventList = new ArrayList<>();
 
           @Override public void onCompleted() {
             listener.onEventListLoaded(eventList);
-            subscription = null;
           }
 
           @Override public void onError(Throwable throwable) {
@@ -53,9 +70,16 @@ public class EventListInteractor {
   }
 
   public void unbind() {
+    unbindSubscription(eventListSubscription);
+    eventListSubscription = null;
+
+    unbindSubscription(vaultSyncSubscription);
+    vaultSyncSubscription = null;
+  }
+
+  private void unbindSubscription(Subscription subscription) {
     if (subscription != null) {
       subscription.unsubscribe();
-      subscription = null;
     }
   }
 }


### PR DESCRIPTION
Before, the app did not wait for the initial sync from the backend. Now on successful return
from the backend, we request the events synced.

fixes https://github.com/gdg-berlin-android/gdg-events-app/issues/1
